### PR TITLE
Fixes #4 - Don't run the container as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,18 @@ MAINTAINER Peter Dave Hello <hsu@peterdavehello.org>
 
 RUN echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories && \
     apk -U upgrade && \
-    apk -v add tor@edge curl && \
+    apk -v add shadow tor@edge curl && \
     rm -rf /var/cache/apk/*
-RUN tor --version
+RUN tor --version && mkdir /tor && chown -Rh tor. /tor && chmod -R 700 /tor
 ADD torrc /etc/tor/
+ADD launch.sh /
+RUN chmod u+x launch.sh
 
 HEALTHCHECK --timeout=10s --start-period=60s \
     CMD curl --fail --socks5-hostname localhost:9150 -I -L 'https://cdnjs.com/' || exit 1
 
 EXPOSE 9150
 
-CMD /usr/bin/tor -f /etc/tor/torrc
+VOLUME ["/tor"]
+
+CMD /launch.sh

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ The super easy way to setup a [Tor](https://www.torproject.org) [SOCKS5](https:/
     $ docker stop tor_socks_proxy
     ```
 
+5. The Process in the Container is not running as root:
+    Instead it is run as user `tor` with userid `100`.
+    If you require the user to be a specifc one (e.g. one which is available on the host), then use the environment variable `USERID` (e.g. by passing `-e USERID=1000` to docker run).
+    On most OS the UID 1000 is the first non-system user. This is particularly useful, if you want to access tor's data directory by accessing the volume /tor (e.g. `-v $(pwd)/data:/tor`),
+    because then you can access the files with your regular file manager without issues. Type `id -u` to check out the current users uid.
+
 ## How to renew IP?
 
  - To renew the IP that Tor gives you, simply restart your docker container:

--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,6 @@
+# Check if USERID is numeric. Since we're on busybox, use grep
+# What actually happens here is that we change the UID of the tor user to $USERID, so that when /tor is mounted, the permissions match
+# If no USERID is specified, we do NOT run as root though, but as user tor
+echo ${USERID:-""} | grep -E '^[0-9]+$' && usermod -u $USERID -o tor && chown -R tor /tor
+echo ${GROUPID:-""} | grep -E '^[0-9]+$' && groupmod -g $GROUPID -o tor
+/usr/bin/tor -f /etc/tor/torrc

--- a/torrc
+++ b/torrc
@@ -1,2 +1,4 @@
 Log notice stdout
 SocksPort 0.0.0.0:9150
+DataDirectory /tor
+User tor


### PR DESCRIPTION
Hey :slightly_smiling_face: 
I'm sorry, I know this is a rather terrible pull-request as it mixes changes to the documentation and code and I didn't ask for your opinion on how to solve things but since I'm in a hurry and this PR should be rather basic, I guess it's easy to work on it, if necessary.

The Readme change is actually explaining the commit so only two things which _can_ be changed:
In theory, since the world readable folder did not work, we could use `/var/lib/tor` instead of `/tor` and not have `/tor` a volume, however it does not do harm, in the worst case it's only useless, when no-one wants to access the data directory.

The config file as is, is still owned by the root user though, because tor itself does the privilege dropping during init.