### PR TITLE
Enable Tor DNSPort

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ COPY torrc /etc/tor/
 HEALTHCHECK --timeout=10s --start-period=60s \
     CMD curl --fail --socks5-hostname localhost:9150 -I -L 'https://www.facebookcorewwwi.onion/' || exit 1
 
-EXPOSE 53 9150
+EXPOSE 53/udp 9150
 
 CMD ["/usr/bin/tor", "-f", "/etc/tor/torrc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ COPY torrc /etc/tor/
 HEALTHCHECK --timeout=10s --start-period=60s \
     CMD curl --fail --socks5-hostname localhost:9150 -I -L 'https://www.facebookcorewwwi.onion/' || exit 1
 
-EXPOSE 9150
+EXPOSE 53 9150
 
 CMD ["/usr/bin/tor", "-f", "/etc/tor/torrc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ COPY torrc /etc/tor/
 HEALTHCHECK --timeout=10s --start-period=60s \
     CMD curl --fail --socks5-hostname localhost:9150 -I -L 'https://www.facebookcorewwwi.onion/' || exit 1
 
-EXPOSE 53/udp 9150
+EXPOSE 53 9150
 
 CMD ["/usr/bin/tor", "-f", "/etc/tor/torrc"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,6 @@ services:
     container_name: tor-socks-proxy
     image: peterdavehello/tor-socks-proxy:latest
     ports:
+      - "127.0.0.1:53:53/udp"
       - "127.0.0.1:9150:9150"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     container_name: tor-socks-proxy
     image: peterdavehello/tor-socks-proxy:latest
     ports:
-      - "127.0.0.1:53:53/udp"
+      - "127.0.0.1:53:53"
       - "127.0.0.1:9150:9150"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     container_name: tor-socks-proxy
     image: peterdavehello/tor-socks-proxy:latest
     ports:
-      - "127.0.0.1:53:53"
+      - "127.0.0.1:53:53/udp"
       - "127.0.0.1:9150:9150"
     restart: unless-stopped

--- a/torrc
+++ b/torrc
@@ -3,3 +3,4 @@ HardwareAccel 1
 Log notice stdout
 SocksPort 0.0.0.0:9150
 DataDirectory /var/lib/tor
+DNSPort 0.0.0.0:9453  # Non-root user can't use port number below 1024

--- a/torrc
+++ b/torrc
@@ -1,6 +1,6 @@
 User tor
 HardwareAccel 1
 Log notice stdout
+DNSPort 0.0.0.0:53
 SocksPort 0.0.0.0:9150
 DataDirectory /var/lib/tor
-DNSPort 0.0.0.0:9453  # Non-root user can't use port number below 1024


### PR DESCRIPTION
Enable Tor's DNSPort support

ex: dig @container_ip -p 9453 example.com