### PR TITLE
Change DNS and Socks address to localhost

### DIFF
--- a/torrc
+++ b/torrc
@@ -1,5 +1,5 @@
 HardwareAccel 1
 Log notice stdout
-DNSPort 0.0.0.0:8853
-SocksPort 0.0.0.0:9150
+DNSPort 127.0.0.1:8853
+SocksPort 127.0.0.1:9150
 DataDirectory /var/lib/tor


### PR DESCRIPTION
127.0.0.1 is the correct address for localhost, whereas 0.0.0.0 is meant to designate an invalid target. Also, it produces warnings:

```
[warn] You specified a public address '0.0.0.0:8853' for DNSPort. Other people on the Internet might find your computer and use it as an open proxy. Please don't allow this unless you have a good reason.
[warn] You specified a public address '0.0.0.0:9150' for SocksPort. Other people on the Internet might find your computer and use it as an open proxy. Please don't allow this unless you have a good reason.
[warn] You specified a public address '0.0.0.0:8853' for DNSPort. Other people on the Internet might find your computer and use it as an open proxy. Please don't allow this unless you have a good reason.
```