### PR TITLE
added --no-cache and better permissions for user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,12 @@ LABEL version="latest"
 RUN echo '@edge https://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories && \
     echo '@edge https://dl-cdn.alpinelinux.org/alpine/edge/testing'   >> /etc/apk/repositories && \
     apk -U upgrade && \
-    apk -v add tor@edge obfs4proxy@edge curl && \
-    chmod 700 /var/lib/tor && \
-    rm -rf /var/cache/apk/* && \
+    apk -v add --no-cache tor@edge obfs4proxy@edge curl && \
+    chown -R tor /var/lib/tor/ && \
+    rm -rf /tmp/* && \
     tor --version
-COPY --chown=tor:root torrc /etc/tor/
+
+COPY --chown=tor torrc /etc/tor/
 
 HEALTHCHECK --timeout=10s --start-period=60s \
     CMD curl --fail --socks5-hostname localhost:9150 -I -L 'https://www.facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion/' || exit 1
@@ -19,4 +20,4 @@ HEALTHCHECK --timeout=10s --start-period=60s \
 USER tor
 EXPOSE 8853/udp 9150/tcp
 
-CMD ["/usr/bin/tor", "-f", "/etc/tor/torrc"]
+ENTRYPOINT ["/usr/bin/tor", "-f", "/etc/tor/torrc"]


### PR DESCRIPTION
added --no-cache option and changed the removed directory to only /tmp/ better permissions for tor user, the default one is enough to be safe changed CMD to ENTRYPOINT, it's just for standarization