### PR TITLE
Replace obfs4proxy with Lyrebird

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL version="latest"
 RUN echo '@edge https://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories && \
     echo '@edge https://dl-cdn.alpinelinux.org/alpine/edge/testing'   >> /etc/apk/repositories && \
     apk -U upgrade && \
-    apk -v add tor@edge obfs4proxy@edge curl && \
+    apk -v add tor@edge lyrebird@edge curl && \
     chmod 700 /var/lib/tor && \
     rm -rf /var/cache/apk/* && \
     tor --version

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ curl --socks5-hostname 127.0.0.1:9150 https://ipinfo.tw/ip
 docker stop tor-socks-proxy
 ```
 
+### Using bridges
+
+Edit `/etc/tor/torrc` and the following:
+
+```
+Bridge obfs4 ...
+Bridge obfs4 ...
+Bridge obfs4 ...
+Bridge obfs4 ...
+
+ClientTransportPlugin obfs4 exec /usr/bin/lyrebird
+UseBridges 1
+```
+
 ## IP Renewal
 
 By default, Tor automatically changes IPs every 10 minutes. You can manually renew the IP by restarting the container:


### PR DESCRIPTION
obfs4proxy was replaced with Lyrebird. Also updated the readme on how to use it

cc #34 